### PR TITLE
remove forked run option from ci while its broken

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
-          pip install coverage pytest-forked pytest-github-actions-annotate-failures
-      - run: python robot.py test -- -v --forked
+          pip install coverage pytest-github-actions-annotate-failures
       - run: python robot.py coverage test -- -v
       - uses: codecov/codecov-action@v3
 


### PR DESCRIPTION
runner seems to be broken thanks to ctre at the moment. This just disables that run option for the time being but it should be re-enabled when possible - potentially once they release their official bindings in the coming days.