### PR TITLE
Configure mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,18 @@ exclude_lines = [
 	"if typing.TYPE_CHECKING:",
 ]
 
+[tool.mypy]
+check_untyped_defs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_unreachable = true
+strict_equality = true
+
+[[tool.mypy.overrides]]
+module = "phoenix6.*"
+# https://github.com/CrossTheRoadElec/Phoenix-Releases/issues/61#issuecomment-1890171743
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 pythonpath = '.'
 


### PR DESCRIPTION
This copies the mypy config from pycubehammer, and additionally configures mypy to ignore `phoenix6` missing type hints.