### PR TITLE
pdm: Refresh lock file with Python 3.10 wheels

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -66,6 +66,17 @@ dependencies = [
     "pycparser",
 ]
 files = [
+    {file = "cffi-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6b3d6606d369fc1da4fd8c357d026317fbb9c9b75d36dc16e90e84c26854b088"},
+    {file = "cffi-1.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ac0f5edd2360eea2f1daa9e26a41db02dd4b0451b48f7c318e217ee092a213e9"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7e61e3e4fa664a8588aa25c883eab612a188c725755afff6289454d6362b9673"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a72e8961a86d19bdb45851d8f1f08b041ea37d2bd8d4fd19903bc3083d80c896"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b50bf3f55561dac5438f8e70bfcdfd74543fd60df5fa5f62d94e5867deca684"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7651c50c8c5ef7bdb41108b7b8c5a83013bfaa8a935590c5d74627c047a583c7"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4108df7fe9b707191e55f33efbcb2d81928e10cea45527879a4749cbe472614"},
+    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:32c68ef735dbe5857c810328cb2481e24722a59a2003018885514d4c09af9743"},
+    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:673739cb539f8cdaa07d92d02efa93c9ccf87e345b9a0b556e3ecc666718468d"},
+    {file = "cffi-1.16.0-cp310-cp310-win32.whl", hash = "sha256:9f90389693731ff1f659e55c7d1640e2ec43ff725cc61b04b2f9c6d8d017df6a"},
+    {file = "cffi-1.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:e6024675e67af929088fda399b2094574609396b1decb609c55fa58b028a32a1"},
     {file = "cffi-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b84834d0cf97e7d27dd5b7f3aca7b6e9263c56308ab9dc8aae9784abb774d404"},
     {file = "cffi-1.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1b8ebc27c014c59692bb2664c7d13ce7a6e9a629be20e54e7271fa696ff2b417"},
     {file = "cffi-1.16.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee07e47c12890ef248766a6e55bd38ebfb2bb8edd4142d56db91b21ea68b7627"},
@@ -152,7 +163,7 @@ files = [
 
 [[package]]
 name = "hypothesis"
-version = "6.92.9"
+version = "6.93.1"
 requires_python = ">=3.8"
 summary = "A library for property-based testing"
 groups = ["dev"]
@@ -162,8 +173,8 @@ dependencies = [
     "sortedcontainers<3.0.0,>=2.1.0",
 ]
 files = [
-    {file = "hypothesis-6.92.9-py3-none-any.whl", hash = "sha256:8c1ab9f3c883fe63a712bb6c8c1b5be4185cad52775cd7703c040fc0d0111572"},
-    {file = "hypothesis-6.92.9.tar.gz", hash = "sha256:629f31788243559d35d3101ef8e94caf736cf8efaad3f0dd66ec7dbb31b8ef19"},
+    {file = "hypothesis-6.93.1-py3-none-any.whl", hash = "sha256:f2c32911c5ebde7097ac8715670daed0b6fb3431501c2b80cf39ba6bbc66cd7c"},
+    {file = "hypothesis-6.93.1.tar.gz", hash = "sha256:637dc3cfb6ba7ac65b4599013f7b364dd99eeacd78e472c196e806ceada7519f"},
 ]
 
 [[package]]
@@ -184,6 +195,14 @@ requires_python = ">=3.9"
 summary = "Fundamental package for array computing in Python"
 groups = ["default"]
 files = [
+    {file = "numpy-1.26.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:806dd64230dbbfaca8a27faa64e2f414bf1c6622ab78cc4264f7f5f028fee3bf"},
+    {file = "numpy-1.26.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02f98011ba4ab17f46f80f7f8f1c291ee7d855fcef0a5a98db80767a468c85cd"},
+    {file = "numpy-1.26.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6d45b3ec2faed4baca41c76617fcdcfa4f684ff7a151ce6fc78ad3b6e85af0a6"},
+    {file = "numpy-1.26.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdd2b45bf079d9ad90377048e2747a0c82351989a2165821f0c96831b4a2a54b"},
+    {file = "numpy-1.26.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:211ddd1e94817ed2d175b60b6374120244a4dd2287f4ece45d49228b4d529178"},
+    {file = "numpy-1.26.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b1240f767f69d7c4c8a29adde2310b871153df9b26b5cb2b54a561ac85146485"},
+    {file = "numpy-1.26.3-cp310-cp310-win32.whl", hash = "sha256:21a9484e75ad018974a2fdaa216524d64ed4212e418e0a551a2d83403b0531d3"},
+    {file = "numpy-1.26.3-cp310-cp310-win_amd64.whl", hash = "sha256:9e1591f6ae98bcfac2a4bbf9221c0b92ab49762228f38287f6eeb5f3f55905ce"},
     {file = "numpy-1.26.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b831295e5472954104ecb46cd98c08b98b49c69fdb7040483aff799a755a7374"},
     {file = "numpy-1.26.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9e87562b91f68dd8b1c39149d0323b42e0082db7ddb8e934ab4c292094d575d6"},
     {file = "numpy-1.26.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c66d6fec467e8c0f975818c1796d25c53521124b7cfb760114be0abad53a0a2"},
@@ -244,7 +263,6 @@ dependencies = [
     "setuptools",
 ]
 files = [
-    {file = "phoenix6-24.1.0-cp39-abi3-linux_roborio.whl", hash = "sha256:1740f4d33c14484ce1902374dc9aa90dd97fc1e7445d96a27b20d70b08ee3565"},
     {file = "phoenix6-24.1.0-cp39-abi3-macosx_10_16_universal2.whl", hash = "sha256:65b687a22b462e48db0e02224f43b641a9a8d4df7c7c06cdf60da097fce8be60"},
     {file = "phoenix6-24.1.0-cp39-abi3-manylinux_2_35_aarch64.whl", hash = "sha256:c3c75782066665be9d37d3641c061be4bf1460e838f482c8f5723e754080ba76"},
     {file = "phoenix6-24.1.0-cp39-abi3-manylinux_2_35_armv7l.whl", hash = "sha256:48f79760706515157512d4596a2964c327235da53dd7b4cadbc50c4bd61b3b65"},
@@ -355,14 +373,12 @@ dependencies = [
     "robotpy-wpiutil==2024.1.1.1",
 ]
 files = [
-    {file = "pyntcore-2024.1.1.1-cp311-cp311-linux_aarch64.whl", hash = "sha256:41c6536d8ec54ebcbb2f922519f5ac4ccdb60a97a34231a3ff5724f30504a0d3"},
-    {file = "pyntcore-2024.1.1.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:90c733c29d7beefef07604209dd2373029106bbc81e94788d6374556bd48240f"},
+    {file = "pyntcore-2024.1.1.1-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:e93aa0c9951722e0b69288c2792f2bc2a7a65d02b26f8e8230de1edc371bf250"},
+    {file = "pyntcore-2024.1.1.1-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:57080b81dbca5e0b28715f19867b848aa5534e09088d5b66d76b64f7cee998ee"},
+    {file = "pyntcore-2024.1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a30e97a6971fadaceacb7e357670d22af55d810d081a8b7cf808db7c62425096"},
     {file = "pyntcore-2024.1.1.1-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:c6bd974f2e0eaa3f9f9705fe641793bc759268d75cb9cc424e20a97d587971e1"},
     {file = "pyntcore-2024.1.1.1-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:089c9721b1aeba6f31f211a9033af9600cabb9148996d1b019cbc03eb4bd3d0b"},
     {file = "pyntcore-2024.1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:803a3ce467527928e22e57c99525a923b79ba716dde9c94d1807b11caba09603"},
-    {file = "pyntcore-2024.1.1.1-cp312-cp312-linux_aarch64.whl", hash = "sha256:1885e603fe9418a5d58f94ec98264b69bf60905b6f4e414be83b2cb33d3c637b"},
-    {file = "pyntcore-2024.1.1.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:470dca2eeeab3d5202aebe9170116d7a3cb2d05c4c834ddc1b758ed928c04369"},
-    {file = "pyntcore-2024.1.1.1-cp312-cp312-linux_roborio.whl", hash = "sha256:56e4ae0e95ad507e1c2dc4f29d22386f7e2e5e354bb736620158e02d8772e38b"},
     {file = "pyntcore-2024.1.1.1-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:479b8ca8d3611f85ab2c5dcca39af299f40db3d7ba4efe9256842f067a4443df"},
     {file = "pyntcore-2024.1.1.1-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:6f0f5a89ae8a70c3994853f2ba1c29a73f3f6acf8becce71c60c232158f9db3f"},
     {file = "pyntcore-2024.1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:6463a5640e52ac0ddda10649babf10616c6278858d5122363d09ff6784dca99e"},
@@ -436,14 +452,12 @@ dependencies = [
     "robotpy-wpiutil==2024.1.1.1",
 ]
 files = [
-    {file = "robotpy_apriltag-2024.1.1.1-cp311-cp311-linux_aarch64.whl", hash = "sha256:871dfa2441d770e269d99cba2a290ad01f86c0772f39b0685083c1e2e1cd1e79"},
-    {file = "robotpy_apriltag-2024.1.1.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:6b5aecac1e769b87d4e1e666e46ffbc8e43cf6fd67d1a26f7402ccbc8da71738"},
+    {file = "robotpy_apriltag-2024.1.1.1-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:f3403cc6490e4bdb304c2400126666406827cef52516b2c7a16ac5af426a79d4"},
+    {file = "robotpy_apriltag-2024.1.1.1-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:6d2a59551ba4c9bf09dfc282bf621b8c003c9bfea613fae245fc751219920a13"},
+    {file = "robotpy_apriltag-2024.1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:8e15aafbd4ad501ae75b5a8eee22c1b8897b9fb519d937d006fc3d284425366c"},
     {file = "robotpy_apriltag-2024.1.1.1-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:e2206d17a3b159c1901ae117ce079afe841e03b64f9f25344a73df24da47eff5"},
     {file = "robotpy_apriltag-2024.1.1.1-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:6b69bc0c3e11f7d5caf8b61974a6886603ffade4cdcc61d721c40bff931dd1a3"},
     {file = "robotpy_apriltag-2024.1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:be4d00b84a63816f072adbdb4b20aa9cebaca24464955fc7a91e66aed215932b"},
-    {file = "robotpy_apriltag-2024.1.1.1-cp312-cp312-linux_aarch64.whl", hash = "sha256:f7eab05f424412dcafaf46608e0955e60d29a637acd1b233df96e33a02f194c2"},
-    {file = "robotpy_apriltag-2024.1.1.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:af3f3522dff38a1ad13e0cf7f302c6573e63524e7b0087915eed8a6883db87bd"},
-    {file = "robotpy_apriltag-2024.1.1.1-cp312-cp312-linux_roborio.whl", hash = "sha256:d8fbc983a3388c383ff323d3fa7843ec0c4392e791013fbe4022139ab43c87d0"},
     {file = "robotpy_apriltag-2024.1.1.1-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:7bf2c2383b970a9033aa6ddecee3a498ed1352a38b9f0201540eed9ffbc01679"},
     {file = "robotpy_apriltag-2024.1.1.1-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:78a7e4dda7d299d2a7e0e4a454178c0360b5af222e594427fe49f31efdb6984a"},
     {file = "robotpy_apriltag-2024.1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:b057bca872f1f0899b69d2a2c335df60564b09451b6a79f8b7f2d72373cb35c4"},
@@ -493,14 +507,12 @@ dependencies = [
     "robotpy-wpiutil==2024.1.1.1",
 ]
 files = [
-    {file = "robotpy_hal-2024.1.1.1-cp311-cp311-linux_aarch64.whl", hash = "sha256:bbafad7f59aecde076fd5c7d0eca2c02ea687bb41636234a53dc8f2d36e4df7a"},
-    {file = "robotpy_hal-2024.1.1.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:1fb34ab28ea8d57dbf41e9dc91f2efb9119e72d21596af8f940d76820a1b9a03"},
+    {file = "robotpy_hal-2024.1.1.1-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:0cd34df381940f89626e1e2b206d2def4879c1cf66b617745447ab5323c24141"},
+    {file = "robotpy_hal-2024.1.1.1-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:b9939b7076268c6f54f633879005685089a68d60b2df0fa52830b20c58af02cf"},
+    {file = "robotpy_hal-2024.1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:b9945c69fb063f49db01ae4b335a92689d42cc1068efadff37403390a19169f9"},
     {file = "robotpy_hal-2024.1.1.1-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:79d0810b4aee3769ee573e9d6a74f448940efea8ffaf70d86840db40122ce652"},
     {file = "robotpy_hal-2024.1.1.1-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:df21128092e932490923b49f6aa9741dbdb3a225805f60900b13d1ededeee38e"},
     {file = "robotpy_hal-2024.1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:93626c3a9fbb2ffa9a9dde9680675c845c173811a8b73bbc4790b50cf0d307ad"},
-    {file = "robotpy_hal-2024.1.1.1-cp312-cp312-linux_aarch64.whl", hash = "sha256:e8f4a723c0b470288fe96ac926d589f33bd30de7621c1e9962f0e0091d31ed75"},
-    {file = "robotpy_hal-2024.1.1.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:3b1b56348add193a4cb34d8c07e27fc72f3f5deea581fe5f09b43ad505aad099"},
-    {file = "robotpy_hal-2024.1.1.1-cp312-cp312-linux_roborio.whl", hash = "sha256:8d2ea44324bb2ec3f050dda42fb35b0de3d484759a114b824861980cfde0cb47"},
     {file = "robotpy_hal-2024.1.1.1-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:547452b6a2c89ed1ca74eb4523da183bb5c0c0b7281823ce197fe99a738dee29"},
     {file = "robotpy_hal-2024.1.1.1-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:d201bbd0529701f150806abdf1c77c5203ee3fc82656fb7c9863d43b9ac3a364"},
     {file = "robotpy_hal-2024.1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:19e445a2bd24e178e5a6ed583a21f8622da1ec214c0953c2cb028ff67b973b28"},
@@ -520,13 +532,12 @@ dependencies = [
     "robotpy-wpiutil==2024.1.1.1",
 ]
 files = [
-    {file = "robotpy_halsim_gui-2024.1.1.1-cp311-cp311-linux_aarch64.whl", hash = "sha256:1310f870611b0e7069cb537a6db4921e028b94124cd2e68ece71f0e32931572d"},
-    {file = "robotpy_halsim_gui-2024.1.1.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:ffe0511807951d01cb9004c9b8cac574b3be61784d6e35ede44e9878827100dc"},
+    {file = "robotpy_halsim_gui-2024.1.1.1-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:bce89ffd57caab38b77e90b406d9ca6e02f9f6c05c48a10e451f2648184690a9"},
+    {file = "robotpy_halsim_gui-2024.1.1.1-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:a351177fecd20bf27ae38305c85388b8cd5b832965725855d3bd27b668ed5016"},
+    {file = "robotpy_halsim_gui-2024.1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:37b769bf1b8de7aa6d0d5c9e0f15f6c17694427778d85430ddfa4326464c84d5"},
     {file = "robotpy_halsim_gui-2024.1.1.1-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:6b48f2e3af194fc3184f551ebe9127c119563cd493272d8a917818d836b2f7dc"},
     {file = "robotpy_halsim_gui-2024.1.1.1-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:830d9669e31b3270654d9b8f2326cd587a1666dc174394da3b612165949accc7"},
     {file = "robotpy_halsim_gui-2024.1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:1a396f5bb485b0ee2ed378b037fce589eba475525347cc5787efb72c41d2ad0e"},
-    {file = "robotpy_halsim_gui-2024.1.1.1-cp312-cp312-linux_aarch64.whl", hash = "sha256:51ebf30bccc1813cac15e53f215a59b62852b3f3e5d9aa25ec37686cb814d345"},
-    {file = "robotpy_halsim_gui-2024.1.1.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:5220c436b203a3dc5072027f7a1c0b50797c7208480932a68a85f85b51b909a9"},
     {file = "robotpy_halsim_gui-2024.1.1.1-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:da93b6d396a6eab81ee81adaf8ea0cd69cc579c510c1e3a5663615b98393f1b9"},
     {file = "robotpy_halsim_gui-2024.1.1.1-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:814473b3714be8f306a9a111b09d8574da36f6b62ffa9a356ec76310d822e3d9"},
     {file = "robotpy_halsim_gui-2024.1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:cc6353ad02775be38ef9ff996462c44292505b422a5279da78397370138f28bd"},
@@ -534,7 +545,7 @@ files = [
 
 [[package]]
 name = "robotpy-installer"
-version = "2024.0.4"
+version = "2024.0.5"
 requires_python = ">=3.8"
 summary = "Installation utility program for RobotPy"
 groups = ["default"]
@@ -547,8 +558,8 @@ dependencies = [
     "tomli",
 ]
 files = [
-    {file = "robotpy-installer-2024.0.4.tar.gz", hash = "sha256:f332f392b1590fcbfb4cfc0b5f0de17a6605e03cecbbc5895ba485be499168ed"},
-    {file = "robotpy_installer-2024.0.4-py3-none-any.whl", hash = "sha256:fc7641d9134901c2ef305f34e47419d123aad83bcdae22f06b6fecc729003aac"},
+    {file = "robotpy-installer-2024.0.5.tar.gz", hash = "sha256:38eb26dbbe32076f5cf95b995190678f041048353c0dc8c8e6a1a70c6a23f226"},
+    {file = "robotpy_installer-2024.0.5-py3-none-any.whl", hash = "sha256:07f9d1342db914a9eed17d42fda5b082381c5736143ef5c0f46ce160934bbce3"},
 ]
 
 [[package]]
@@ -564,14 +575,12 @@ dependencies = [
 ]
 files = [
     {file = "robotpy-navx-2024.1.0.tar.gz", hash = "sha256:816d52d172ff1bfc87f10a91fbbeb36f873f6e02a1c16fb3befdcad73cf266f2"},
-    {file = "robotpy_navx-2024.1.0-cp311-cp311-linux_aarch64.whl", hash = "sha256:1c30f96afc4e8a40b7f53c857336039b64442e57875927dcbf46227af3cd634e"},
-    {file = "robotpy_navx-2024.1.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:f478ee7617e54a606b77c5f6b682f35ec09a13073701a4a288b917ff39414db0"},
+    {file = "robotpy_navx-2024.1.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:a56f6c71678b23cd3f9ce376d7040243b921c01dda8d0de8a828b4a2db45d6e2"},
+    {file = "robotpy_navx-2024.1.0-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:00282c61864bfcbd104cbe2ee10b0bcfb517adb27586f43cc89a631c9d471189"},
+    {file = "robotpy_navx-2024.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:1e24ba17aa30bd926569cd3def6ae1c96b64ba1a02a7c87a42c51b16d82a613a"},
     {file = "robotpy_navx-2024.1.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:44bbf7bbfaa26ecf59a8a361842f5e89bb7ab44116e4b6a82675d98813c7e045"},
     {file = "robotpy_navx-2024.1.0-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:5e5b7389dac357825c76fe69e09475d00477c2a1de2b6b6b7ef00f4461e6cf06"},
     {file = "robotpy_navx-2024.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:ba22ed1be09525ebb35e9a5ee1a4eca7953848a8b0fec167398e167db9490025"},
-    {file = "robotpy_navx-2024.1.0-cp312-cp312-linux_aarch64.whl", hash = "sha256:b110c82776380dc29488936c18ff03c96c0e6b817f2a3af9fd86d9fd3e086d77"},
-    {file = "robotpy_navx-2024.1.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:aa4f19db9960d4be2f8b164920f51afed03a1636f0bdb42324c3270dfaf44439"},
-    {file = "robotpy_navx-2024.1.0-cp312-cp312-linux_roborio.whl", hash = "sha256:bd0d1c7ddd8b15210179ae2136b630c788a2135ecc3bd6261796b6f752d35b56"},
     {file = "robotpy_navx-2024.1.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:0c3e382fe21196d3eeaa906d9e82b18711af7690d159cb7af999b8a733d39ebb"},
     {file = "robotpy_navx-2024.1.0-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:a6757655b2aaa1d8028068f22b4c0fbddcb38d3189f9efcaa6f97204d70d2632"},
     {file = "robotpy_navx-2024.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:6e2fc4c871a20d305fb9f6ba5cb5cb424f9a31b78327b77c3f7e28c2437f84d8"},
@@ -590,14 +599,12 @@ dependencies = [
 ]
 files = [
     {file = "robotpy-rev-2024.2.0.tar.gz", hash = "sha256:d5bff680765dadb2685a29640804259bfa3794a7b918d9242b6c27895e6e8417"},
-    {file = "robotpy_rev-2024.2.0-cp311-cp311-linux_aarch64.whl", hash = "sha256:3ebacf2243d4f1b76b781fcca8e12d5627fa5074f347e981583513f0bd42b606"},
-    {file = "robotpy_rev-2024.2.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:555705d4f3f9cfcd21e653e29088670b7ade49fe9a5a986b53e2155f0498b8de"},
+    {file = "robotpy_rev-2024.2.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:a62b32f743ef9e27c54443819544e31cdaaccbf24db07c4766d055958864b409"},
+    {file = "robotpy_rev-2024.2.0-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:48634ff5bb8cf0fc9233fa8f69fb2387d08d59758f9536d762bb8e7374351834"},
+    {file = "robotpy_rev-2024.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:8673fbc3ceb5f69674560f1877128429d3365bf1e61594b70d593322ca455960"},
     {file = "robotpy_rev-2024.2.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:dfcd8c4497e09cb83d9370ddb98c5ae9683b3a9d90b8e5de126a490061244ceb"},
     {file = "robotpy_rev-2024.2.0-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:bcb2679eaeb73a90e83694192e64fa8c3a87856ec42edfc16ffa0f718fb2400f"},
     {file = "robotpy_rev-2024.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:ffd8748e1425f674c1fb0fe51620f7da9f40c11a7643f9c03139747e7237aea0"},
-    {file = "robotpy_rev-2024.2.0-cp312-cp312-linux_aarch64.whl", hash = "sha256:ec310f1cbd6a4b88be96f28956661c7314b49c3111be9c07c88f6e13ff9bee27"},
-    {file = "robotpy_rev-2024.2.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:205a552c1f103f5cb432555bb79c4513c2dea11c779ba91884ea8b27019305b9"},
-    {file = "robotpy_rev-2024.2.0-cp312-cp312-linux_roborio.whl", hash = "sha256:03ba9df778ccd6841e3a1ca13faddb62bc518ee438dee44c6208c0dd3c46bc8c"},
     {file = "robotpy_rev-2024.2.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:4f981f40cb848cbffa1d678fdaa8d05ebd1c727bc0572142626714c79ba6bcd9"},
     {file = "robotpy_rev-2024.2.0-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:3df12e1c5d9df3a4492abfc8d192006182d4356b687708edf214e1b683911017"},
     {file = "robotpy_rev-2024.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:d021d19d2116279aa912edd93b6864fc36c624aa138f0a54a628df210ff97a0f"},
@@ -627,14 +634,12 @@ dependencies = [
     "robotpy-wpiutil==2024.1.1.1",
 ]
 files = [
-    {file = "robotpy_wpimath-2024.1.1.1-cp311-cp311-linux_aarch64.whl", hash = "sha256:d1a095d7f780bcc1467e5858ef71b37f77061796605faf2668386538d44f6a92"},
-    {file = "robotpy_wpimath-2024.1.1.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:a7b7d0d651c52bf75d721be7de1f0b03ffc267ed94290a059740db35a89799e9"},
+    {file = "robotpy_wpimath-2024.1.1.1-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:59466913060a697fee4cd1afc63b5b72397281f9e0019f3a8cc6a1a6dbfa252e"},
+    {file = "robotpy_wpimath-2024.1.1.1-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:fd7f3e247e248c2442ed8dab5b7b807a702576c3eab9d6725796af172d4102fc"},
+    {file = "robotpy_wpimath-2024.1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:35eb656efcd6cf1d50b8a0ebe5b802c5f0581b6d20df934f8dd1fcb77d120192"},
     {file = "robotpy_wpimath-2024.1.1.1-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:7167ea5181c815fe10f3e46df495ffc08ae2f90dbf399d455fe3c72643602394"},
     {file = "robotpy_wpimath-2024.1.1.1-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:7b27bf280c9ae55e874b2e46f9174a3b07896ee9e4d5b90c4e16dab5173ad72e"},
     {file = "robotpy_wpimath-2024.1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:649ce400c5f3b45deaf73dbd8223be71fcb44f61d41d665bbf21ad947a7d5df3"},
-    {file = "robotpy_wpimath-2024.1.1.1-cp312-cp312-linux_aarch64.whl", hash = "sha256:4d3720fc0576a6073f8b0c69277c448ed0d60fbd40ce020abad4afcc582cabae"},
-    {file = "robotpy_wpimath-2024.1.1.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:5b368d216b86469e8e1b39fd98aaf9520ce13169e7d8e7eb50a403e7b0e2ba6c"},
-    {file = "robotpy_wpimath-2024.1.1.1-cp312-cp312-linux_roborio.whl", hash = "sha256:50e64f2f31e31acc1df968de9196aa71fd242e563eee6108168f0590bdb85616"},
     {file = "robotpy_wpimath-2024.1.1.1-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:f987609fec0adbf253e47388812f61969c2ffcec1958f63a097bb5a3515c1e24"},
     {file = "robotpy_wpimath-2024.1.1.1-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:81e850df98fd62e8497a49b2bceec4014b9ed3cea155642fa4e034f77d870e18"},
     {file = "robotpy_wpimath-2024.1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:bba421856198139d5c2384a66e04a18d47562ba1c7aaa78e4374a586bbafe427"},
@@ -650,14 +655,12 @@ dependencies = [
     "robotpy-wpiutil==2024.1.1.1",
 ]
 files = [
-    {file = "robotpy_wpinet-2024.1.1.1-cp311-cp311-linux_aarch64.whl", hash = "sha256:811f2aa35cb8f445af847b19776b946141d0ee9c8a73c37d883c5ff645773175"},
-    {file = "robotpy_wpinet-2024.1.1.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:df5c128a5aed0ce81cfcc67dcb7e68a1f5fb6a8bd7a6b55226d618cdc5d0fce4"},
+    {file = "robotpy_wpinet-2024.1.1.1-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:52d0fbb187120416846261d3a1150282a33542a672495fdd5189d0f0d7f211a4"},
+    {file = "robotpy_wpinet-2024.1.1.1-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:3a07601b53193179310e8d433d1100ff554f62e87ffd62daf8c9470847b0cce8"},
+    {file = "robotpy_wpinet-2024.1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a9dc643a8a00055cbc7d6998ae02fbfa92da81498da4a105ee2edb76d7ef8319"},
     {file = "robotpy_wpinet-2024.1.1.1-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:1faf0a5cb40b27538ff20ba1e5a098490f4106a3704c89403a4851a844c25a1e"},
     {file = "robotpy_wpinet-2024.1.1.1-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:94bf23400e7891f9ee4665570c1f5fc638bf8c89049d508af2b99a31c81d2c49"},
     {file = "robotpy_wpinet-2024.1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:6a58178cab524f6943027dd93a8e2ace92b2a23cdefac596297aabf15830f28e"},
-    {file = "robotpy_wpinet-2024.1.1.1-cp312-cp312-linux_aarch64.whl", hash = "sha256:4a3aedb12efa0c89e3f8018e55fecef8628b89b77608644379c37122108bd5cc"},
-    {file = "robotpy_wpinet-2024.1.1.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:096634ee8f305bb4adb7a7fecd7e6525f350786bcd48f5f7d78a7b559c35745c"},
-    {file = "robotpy_wpinet-2024.1.1.1-cp312-cp312-linux_roborio.whl", hash = "sha256:51aa01d21966e53f43f7ad0b924b343fbfb230222c454026ad716e134c247a42"},
     {file = "robotpy_wpinet-2024.1.1.1-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:2816bf1c4dd18412b63c9526e413852f784d680e7b1def0eb9426496ee543bc8"},
     {file = "robotpy_wpinet-2024.1.1.1-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:8ed88d6aa152be5899ff5ac441aebf53dffb529cda552e82031687d1bb13e4a7"},
     {file = "robotpy_wpinet-2024.1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:04084d2289de0b1982ec71f9690f20bb62ac0606ba13bafaf087397979f5b168"},
@@ -670,14 +673,12 @@ requires_python = ">=3.8"
 summary = "Binary wrapper for FRC WPIUtil library"
 groups = ["default"]
 files = [
-    {file = "robotpy_wpiutil-2024.1.1.1-cp311-cp311-linux_aarch64.whl", hash = "sha256:c6203c124735adee1a3c2f289bfcef9a84105d1e69e620ed2cd2f4fa772201fe"},
-    {file = "robotpy_wpiutil-2024.1.1.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:f1501a262f4a58bdbae5e482a4ffa726b09d837f101f94bb9bbf14916e4be9b0"},
+    {file = "robotpy_wpiutil-2024.1.1.1-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:0d8579546617a5e2967b1e3325a6778ca6e56d87585b09f766258077722fcc47"},
+    {file = "robotpy_wpiutil-2024.1.1.1-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:3c72957302d7caa65f2a71274889e481a8b3490bd7bd425cef0340defe09b179"},
+    {file = "robotpy_wpiutil-2024.1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:1aa7bc8abd9635517119ccd6a322e28a5da5ab92bf1c66c0b90ffbb865549710"},
     {file = "robotpy_wpiutil-2024.1.1.1-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:0b552be4e0d5f411237e70a4c9fed959906917f9e5681e5db8b06b17ac857a56"},
     {file = "robotpy_wpiutil-2024.1.1.1-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:0084575cd93088ab71ee3140506ef497ae3292cab4c786dbf3f8f7b19333b6ee"},
     {file = "robotpy_wpiutil-2024.1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:fd98ab7f66447387cb329ed8451736c616dbf4c4d31e9ad746853ea9046ca506"},
-    {file = "robotpy_wpiutil-2024.1.1.1-cp312-cp312-linux_aarch64.whl", hash = "sha256:74edc670012fd1c056b1bc6581bd9c6f62eb83aabe598f94caa7f21118628b13"},
-    {file = "robotpy_wpiutil-2024.1.1.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:0372e12c3e390dbd769645805526c2e023f1cf116ecec2c6b7a4033915d0e9b8"},
-    {file = "robotpy_wpiutil-2024.1.1.1-cp312-cp312-linux_roborio.whl", hash = "sha256:61c8f3ea90339f5cb65268353a3195b94f2e9dea75648a8bbc4b5b0c6b31792e"},
     {file = "robotpy_wpiutil-2024.1.1.1-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:ff4f4be6e5d9d6ac9a0bcc1e72fa7756810e986939bfa1ad2522b597dab7f85c"},
     {file = "robotpy_wpiutil-2024.1.1.1-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:5f62c29d06f9adf5159c82b2b7bdab98d2d247f6cc84df0aebee6570c916f735"},
     {file = "robotpy_wpiutil-2024.1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:3008cb3a9e94ae9a0b2c15aacd4e18886a621723a196a20a459d7419ba504ed3"},
@@ -742,14 +743,12 @@ dependencies = [
     "robotpy-wpiutil==2024.1.1.1",
 ]
 files = [
-    {file = "wpilib-2024.1.1.1-cp311-cp311-linux_aarch64.whl", hash = "sha256:6d069bc3fc2129e32fd46914af88cb415752146ae57e29e55bd626eae428a4f6"},
-    {file = "wpilib-2024.1.1.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:cbe81a4f4800d0d6ebeab2854141a6587431c1c58a24ce5283509a059a28d936"},
+    {file = "wpilib-2024.1.1.1-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:a5ef39347c780cc50d7ef0f079377541298070174654446272b3e392824739ab"},
+    {file = "wpilib-2024.1.1.1-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:9edad7cd2483e514864c0fa4128abf9aeb929d2888c95fbc37a00579daca98c9"},
+    {file = "wpilib-2024.1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:c8172b7ccd416a0335aaf44cc54d2ee6d92a404f880026d9934445977c74e9d0"},
     {file = "wpilib-2024.1.1.1-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:c2816c5fb4febaeb4c7055e5528780103b0ea705084e7d99c5e219d9873a96fb"},
     {file = "wpilib-2024.1.1.1-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:82a2cee6ba2ff21b545388c3752ccbf5eafb60c73188d30a2161e2fce4ec2f7f"},
     {file = "wpilib-2024.1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:6f04c81531e67a3f06e7a50198a21657095f0fc5bdd823cd2ada4931317b2e41"},
-    {file = "wpilib-2024.1.1.1-cp312-cp312-linux_aarch64.whl", hash = "sha256:a85dce034198fd70980092631af5f9754c4778ee493a86094bd9a26864cf44dc"},
-    {file = "wpilib-2024.1.1.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:945e958b1fab4a6bcc4eed7dcdc23bd63e407d3e10216555b7c0f94b3d3408c7"},
-    {file = "wpilib-2024.1.1.1-cp312-cp312-linux_roborio.whl", hash = "sha256:4a163230b2cd96d7ceb22feb4159f78656d5e06d821e9c200e96c9069003c2a0"},
     {file = "wpilib-2024.1.1.1-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:fcfa81321de93933406e313b7f3f89d6300ab5bc9d757c89b4214858fb4393d3"},
     {file = "wpilib-2024.1.1.1-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:e3b4063c4068fadd48e7cfb220476bfd529e59614e0b3f8a825d06115d2a9b44"},
     {file = "wpilib-2024.1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:244745f00b9fc6db7b66b2992a1bfc9c7da5c6951bb85aeda0f277de6589eca6"},


### PR DESCRIPTION
I suspect at the time I initially generated the lock file, I accidentally didn't allow Python 3.10 in the `requires-python` field in pyproject.toml, and then forgot to run `pdm lock` again after updating that field.