### PR TITLE
gitignore the entire logs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,5 @@ dmypy.json
 ### WPILib ###
 networktables.json
 simgui*.json
-*.wpilog
-
-### CTRE ###
+logs/
 ctre_sim/


### PR DESCRIPTION
Include the phoenix6 hoot logs in gitignore, as well as WPILib data logs.