### PR TITLE
Update robotpy-installer

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:aee613a083a5ddf7c3af9641381b2586da0af9e044dfd522f7ae597a9a98e8fa"
+content_hash = "sha256:6ebee88191860a16f334567ab9a59d8ccc4c7330ade878542864081b3be66f3f"
 
 [[package]]
 name = "attrs"
@@ -435,16 +435,17 @@ files = [
 
 [[package]]
 name = "robotpy"
-version = "2024.1.1.1"
+version = "2024.1.1.3"
 requires_python = ">=3.8,<3.13"
 summary = "Meta package to make installing robotpy easier"
 groups = ["default"]
 dependencies = [
     "pyfrc<2025,>=2024.0.0; platform_machine != \"roborio\" and platform_machine != \"armv7l\" and platform_machine != \"aarch64\"",
     "pyntcore==2024.1.1.1",
+    "robotpy-cli<2025,>=2024.0.0",
     "robotpy-hal==2024.1.1.1",
     "robotpy-halsim-gui==2024.1.1.1; platform_machine != \"roborio\" and platform_machine != \"armv7l\" and platform_machine != \"aarch64\"",
-    "robotpy-installer<2025,>=2024.0.2; platform_machine != \"roborio\" and platform_machine != \"armv7l\" and platform_machine != \"aarch64\"",
+    "robotpy-installer<2025,>=2024.0.3; platform_machine != \"roborio\" and platform_machine != \"armv7l\" and platform_machine != \"aarch64\"",
     "robotpy-wpilib-utilities<2025,>=2024.0.0",
     "robotpy-wpimath==2024.1.1.1",
     "robotpy-wpinet==2024.1.1.1",
@@ -452,8 +453,8 @@ dependencies = [
     "wpilib==2024.1.1.1",
 ]
 files = [
-    {file = "robotpy-2024.1.1.1-py3-none-any.whl", hash = "sha256:cacd0912b6622198a9e5864a1accfd2c2264ddb09da8223d2c93054d65925486"},
-    {file = "robotpy-2024.1.1.1.tar.gz", hash = "sha256:b2589cea10a947ea26eb099d9345fe0e5bd400f678fffc2b68d1c7c4f63509e3"},
+    {file = "robotpy-2024.1.1.3-py3-none-any.whl", hash = "sha256:cc9a1dfa216a8208efa848683ce0df45c98f7905c3450f8d61ea32fed4adab9b"},
+    {file = "robotpy-2024.1.1.3.tar.gz", hash = "sha256:a9f9f7de9aac362ec7f027194d11644ad555f4da1951c9ebdf9c6ba8ec15cb36"},
 ]
 
 [[package]]
@@ -560,21 +561,21 @@ files = [
 
 [[package]]
 name = "robotpy-installer"
-version = "2024.0.5"
+version = "2024.1.2"
 requires_python = ">=3.8"
 summary = "Installation utility program for RobotPy"
 groups = ["default"]
 marker = "platform_machine != \"roborio\" and platform_machine != \"armv7l\" and platform_machine != \"aarch64\""
 dependencies = [
-    "packaging",
+    "packaging~=23.2",
     "paramiko",
     "pynetconsole~=2.0.2",
     "robotpy-cli~=2024.0",
     "tomli",
 ]
 files = [
-    {file = "robotpy-installer-2024.0.5.tar.gz", hash = "sha256:38eb26dbbe32076f5cf95b995190678f041048353c0dc8c8e6a1a70c6a23f226"},
-    {file = "robotpy_installer-2024.0.5-py3-none-any.whl", hash = "sha256:07f9d1342db914a9eed17d42fda5b082381c5736143ef5c0f46ce160934bbce3"},
+    {file = "robotpy-installer-2024.1.2.tar.gz", hash = "sha256:2e7692bd6c0d305531bcede806e37e6df15fd446e856dee2670af2283337ed35"},
+    {file = "robotpy_installer-2024.1.2-py3-none-any.whl", hash = "sha256:dde4f529c84b2fcc7b97193419d72c9184531578cdbadf310cdab72f49146110"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "numpy~=1.25",
     "phoenix6==24.1.0",
     # robotpy[apriltag] pins numpy to a version that doesn't build cleanly on Python 3.12.
-    "robotpy==2024.1.1.1",
+    "robotpy==2024.1.1.3",
     "robotpy-apriltag==2024.1.1.1",
     "robotpy-ctre==2024.1.1",
     "robotpy-navx==2024.1.0",
@@ -99,5 +99,5 @@ requires = [
     "robotpy-wpilib-utilities==2024.0.0",
     "photonlibpy==2024.2.0",
 ]
-robotpy_version = "2024.1.1.1"
+robotpy_version = "2024.1.1.3"
 robotpy_extras = ["apriltag"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,10 @@ branch = true
 
 [tool.coverage.report]
 exclude_lines = [
-	"pragma: no cover",
-	"raise NotImplementedError",
-	"if __name__ == .__main__.:",
-	"if typing.TYPE_CHECKING:",
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if typing.TYPE_CHECKING:",
 ]
 
 [tool.mypy]
@@ -29,24 +29,24 @@ target-version = "py39"
 
 [tool.ruff.lint]
 select = [
-	# pycodestyle
-	"E",
-	# pyflakes
-	"F",
-	# flake8-bugbear
-	"B",
-	# pyupgrade
-	"UP",
-	# flake8-comprehensions
-	"C4",
-	# flake8-logging-format
-	"G",
-	# flake8-simplify
-	"SIM",
-	# flake8-print
-	"T20",
-	# perflint
-	"PERF",
+    # pycodestyle
+    "E",
+    # pyflakes
+    "F",
+    # flake8-bugbear
+    "B",
+    # pyupgrade
+    "UP",
+    # flake8-comprehensions
+    "C4",
+    # flake8-logging-format
+    "G",
+    # flake8-simplify
+    "SIM",
+    # flake8-print
+    "T20",
+    # perflint
+    "PERF",
 ]
 ignore = ["E501"]
 
@@ -61,8 +61,8 @@ test = "robotpy test"
 
 [tool.pdm.dev-dependencies]
 dev = [
-	"hypothesis",
-	"pytest>=7.2.0",
+    "hypothesis",
+    "pytest>=7.2.0",
 ]
 
 [project]
@@ -70,34 +70,34 @@ name = "pycrescendo"
 version = "0.0.0"
 description = "The Drop Bears' FRC 2024 robot code"
 authors = [
-	{name = "The Drop Bears", email = "enquiries@thedropbears.org.au"},
+    {name = "The Drop Bears", email = "enquiries@thedropbears.org.au"},
 ]
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10,<3.13"
 
 dependencies = [
-	"numpy~=1.25",
-	"phoenix6==24.1.0",
-	# robotpy[apriltag] pins numpy to a version that doesn't build cleanly on Python 3.12.
-	"robotpy==2024.1.1.1",
-	"robotpy-apriltag==2024.1.1.1",
-	"robotpy-ctre==2024.1.1",
-	"robotpy-navx==2024.1.0",
-	"robotpy-rev==2024.2.0",
-	"robotpy-wpilib-utilities==2024.0.0",
-	"photonlibpy==2024.2.0",
+    "numpy~=1.25",
+    "phoenix6==24.1.0",
+    # robotpy[apriltag] pins numpy to a version that doesn't build cleanly on Python 3.12.
+    "robotpy==2024.1.1.1",
+    "robotpy-apriltag==2024.1.1.1",
+    "robotpy-ctre==2024.1.1",
+    "robotpy-navx==2024.1.0",
+    "robotpy-rev==2024.2.0",
+    "robotpy-wpilib-utilities==2024.0.0",
+    "photonlibpy==2024.2.0",
 ]
 
 [tool.robotpy]
 requires = [
-	"numpy~=1.25",
-	"phoenix6==24.1.0",
-	"robotpy-ctre==2024.1.1",
-	"robotpy-navx==2024.1.0",
-	"robotpy-rev==2024.2.0",
-	"robotpy-wpilib-utilities==2024.0.0",
-	"photonlibpy==2024.2.0",
+    "numpy~=1.25",
+    "phoenix6==24.1.0",
+    "robotpy-ctre==2024.1.1",
+    "robotpy-navx==2024.1.0",
+    "robotpy-rev==2024.2.0",
+    "robotpy-wpilib-utilities==2024.0.0",
+    "photonlibpy==2024.2.0",
 ]
 robotpy_version = "2024.1.1.1"
 robotpy_extras = ["apriltag"]


### PR DESCRIPTION
We're seeing very odd issues in the version of robotpy-installer we've locked. This updates robotpy-installer in the lock file.