### PR TITLE
Delete .installer_config

### DIFF
--- a/.installer_config
+++ b/.installer_config
@@ -1,2 +1,0 @@
-[auth]
-hostname = 4774


### PR DESCRIPTION
This file is no longer used by `robotpy-installer`, in favour of the `.wpilib/wpilib_preferences.json` file.