### PR TITLE
Fix codecov uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           pdm run python -m ensurepip
           pdm run python -m pip install coverage pytest-github-actions-annotate-failures
       - run: pdm run robotpy coverage test -- -v
+      - run: pdm run coverage xml
       - uses: codecov/codecov-action@v3
 
   mypy:


### PR DESCRIPTION
The codecov uploader would automatically run `coverage xml` to convert Python coverage to XML reports... but since we're now installing into a venv that's not on `$PATH`, that automagic won't work.