### PR TITLE
Append `--` to test script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ package-type = "application"
 deploy = "robotpy deploy"
 download = "robotpy sync --no-install"
 sim = "robotpy sim"
-test = "robotpy test"
+test = "robotpy test --"
 
 [tool.pdm.dev-dependencies]
 dev = [


### PR DESCRIPTION
With this `pdm run test --exitfirst` (or other pytest options) will do the right thing, passing the options to pytest.

`robotpy test` doesn't have any interesting options, so preventing usage of its options shouldn't be an issue.