### PR TITLE
chassis: Rotate test poses by 180º

### DIFF
--- a/components/chassis.py
+++ b/components/chassis.py
@@ -221,7 +221,7 @@ class ChassisComponent:
     do_smooth = magicbot.tunable(True)
     swerve_lock = magicbot.tunable(False)
 
-    RED_TEST_POSE = Pose2d(15.1, 5.5, 0)
+    RED_TEST_POSE = Pose2d(15.1, 5.5, math.pi)
     BLUE_TEST_POSE = field_flip_pose2d(RED_TEST_POSE)
 
     def setup(self) -> None:


### PR DESCRIPTION
We're more likely to want our shooter facing towards the speaker.

| blue | red |
|--------|--------|
| <img width="404" alt="sim screenshot" src="https://github.com/thedropbears/pycrescendo/assets/128854/bd0f16e0-80ae-4994-859c-3eec14e8fdb1"> | <img width="400" alt="sim screenshot" src="https://github.com/thedropbears/pycrescendo/assets/128854/6f0162f7-bd0f-40ce-a3ec-e1ff4dc8d987"> |
