### PR TITLE
fuzz_test: Start in disabled mode

### DIFF
--- a/tests/fuzz_test.py
+++ b/tests/fuzz_test.py
@@ -119,8 +119,9 @@ def test_fuzz_test(control: TestController) -> None:
     with control.run_robot():
         hids = DSInputs()
 
-        DriverStationSim.setDsAttached(True)
-        DriverStationSim.setAutonomous(False)
+        # Start the robot in disabled mode for a short period
+        control.step_timing(seconds=0.5, autonomous=False, enabled=False)
+
         DriverStationSim.setTest(True)
         DriverStationSim.setEnabled(True)
 


### PR DESCRIPTION
This should hopefully fix our deadlocks by allowing the robot to finish initializing before starting test mode.