### PR TITLE
robot: Fix heading snapping direction

### DIFF
--- a/robot.py
+++ b/robot.py
@@ -88,7 +88,7 @@ class MyRobot(magicbot.MagicRobot):
 
         dpad = self.gamepad.getPOV()
         if dpad != -1:
-            self.chassis.snap_to_heading(math.radians(dpad))
+            self.chassis.snap_to_heading(-math.radians(dpad))
 
         # Set current robot direction to forward
         if self.gamepad.getXButton():


### PR DESCRIPTION
In WPILib HIDs use the NED (north east down, clockwise positive) axes convention, but our coordinate system is NWU (north west up, anticlockwise positive).