### PR TITLE
Split injector from shooter component

### DIFF
--- a/components/injector.py
+++ b/components/injector.py
@@ -1,0 +1,47 @@
+import enum
+import magicbot
+import rev
+import wpilib
+
+import ids
+
+
+class Mode(enum.Enum):
+    IDLE = enum.auto()
+    INTAKE = enum.auto()
+    SHOOT = enum.auto()
+
+
+class InjectorComponent:
+    intake_speed = magicbot.tunable(0.5)
+    shoot_speed = magicbot.tunable(1.0)
+
+    def __init__(self) -> None:
+        self.injector = rev.CANSparkMax(
+            ids.SparkMaxIds.shooter_injector, rev.CANSparkMax.MotorType.kBrushless
+        )
+        self.injector.setInverted(False)
+
+        self.break_beam = wpilib.DigitalInput(ids.DioChannels.injector_break_beam)
+
+        self._mode = Mode.IDLE
+
+    def has_note(self) -> bool:
+        return not self.break_beam.get()
+
+    def intake(self) -> None:
+        self._mode = Mode.INTAKE
+
+    def shoot(self) -> None:
+        self._mode = Mode.SHOOT
+
+    def execute(self) -> None:
+        match self._mode:
+            case Mode.IDLE:
+                speed = 0.0
+            case Mode.INTAKE:
+                speed = 0.0 if self.has_note() else self.intake_speed
+            case Mode.SHOOT:
+                speed = self.shoot_speed
+
+        self.injector.set(speed)

--- a/components/shooter.py
+++ b/components/shooter.py
@@ -25,7 +25,6 @@ class ShooterComponent:
 
     desired_inclinator_angle = tunable((MAX_INCLINE_ANGLE + MIN_INCLINE_ANGLE) / 2)
     desired_flywheel_speed = tunable(0.0)
-    inject_speed = tunable(0.3)
 
     def __init__(self) -> None:
         self.inclinator = CANSparkMax(
@@ -58,22 +57,13 @@ class ShooterComponent:
         flywheel_config.apply(flywheel_pid)
         flywheel_config.apply(flywheel_gear_ratio)
 
-        self.injector = CANSparkMax(
-            SparkMaxIds.shooter_injector, CANSparkMax.MotorType.kBrushless
-        )
-        self.injector.setInverted(False)
-
         self.inclinator_controller = PIDController(3, 0, 0)
         self.inclinator_controller.setTolerance(ShooterComponent.INCLINATOR_TOLERANCE)
         SmartDashboard.putData(self.inclinator_controller)
-        self.should_inject = False
 
     def set_inclination(self, angle: float) -> None:
         """Set the angle of the mechanism in radians measured positive upwards from zero parellel to the ground."""
         self.desired_inclinator_angle = angle
-
-    def shoot(self) -> None:
-        self.should_inject = True
 
     def on_enable(self) -> None:
         self.inclinator_controller.reset()
@@ -130,11 +120,5 @@ class ShooterComponent:
         )
         self.inclinator.set(inclinator_speed)
 
-        if self.should_inject:
-            self.injector.set(self.inject_speed)
-        else:
-            self.injector.set(0.0)
-
         flywheel_request = VelocityVoltage(self.desired_flywheel_speed)
         self.flywheel.set_control(flywheel_request)
-        self.should_inject = False

--- a/controllers/shooter.py
+++ b/controllers/shooter.py
@@ -1,13 +1,16 @@
 from math import atan2
 from magicbot import StateMachine, state, timed_state, default_state, will_reset_to
 from components.chassis import ChassisComponent
+from components.injector import InjectorComponent
 from components.shooter import ShooterComponent
 from utilities.game import get_goal_speaker_position
 
 
 class Shooter(StateMachine):
     chassis: ChassisComponent
+    injector_component: InjectorComponent
     shooter_component: ShooterComponent
+
     should_fire = will_reset_to(False)
     INJECTION_DURATION = 1  # seconds
 
@@ -71,7 +74,7 @@ class Shooter(StateMachine):
 
     @timed_state(must_finish=True, next_state="resetting", duration=INJECTION_DURATION)
     def shooting(self) -> None:
-        self.shooter_component.shoot()
+        self.injector_component.shoot()
 
     @state
     def resetting(self) -> None:

--- a/ids.py
+++ b/ids.py
@@ -31,17 +31,18 @@ class CancoderIds(enum.IntEnum):
 @enum.unique
 class SparkMaxIds(enum.IntEnum):
     shooter_injector = 1
-    shooter_inclinator = 2  # TODO Change to the correct ID
+    shooter_inclinator = 2
     climber = 3
 
 
 @enum.unique
 class DioChannels(enum.IntEnum):
-    inclinator_encoder = 1  # TODO Change to the correct ID
+    inclinator_encoder = 1
+    injector_break_beam = 2
     climber_deploy_switch = 3
     climber_retract_switch = 4
 
 
 @enum.unique
 class PwmChannels(enum.IntEnum):
-    led_strip = 1  # TODO Change to the correct ID
+    led_strip = 1

--- a/robot.py
+++ b/robot.py
@@ -7,6 +7,7 @@ import magicbot
 from magicbot import tunable
 
 from components.chassis import ChassisComponent
+from components.injector import InjectorComponent
 from components.vision import VisualLocalizer
 
 from components.shooter import ShooterComponent
@@ -31,6 +32,7 @@ class MyRobot(magicbot.MagicRobot):
 
     # Components
     chassis: ChassisComponent
+    injector_component: InjectorComponent
     shooter_component: ShooterComponent
     intake: IntakeComponent
     climber_component: ClimberComponent
@@ -121,7 +123,7 @@ class MyRobot(magicbot.MagicRobot):
     def testPeriodic(self) -> None:
         # injecting
         if self.gamepad.getBButton():
-            self.shooter_component.shoot()
+            self.injector_component.shoot()
 
         if self.gamepad.getXButton():
             self.intake.intake()


### PR DESCRIPTION
The injector is logically part of both the intake and shooter, so it should be part of neither, to be controlled by a higher-level state machine.