### PR TITLE
Improved lookup table class

### DIFF
--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -5,38 +5,38 @@ from hypothesis.strategies import floats
 from utilities.lookup import LookupTable
 
 test_table = LookupTable(
-    angle=[0.0, 10.0, 12.0, 15.0, 20.0],
+    [0.0, 10.0, 12.0, 15.0, 20.0],
     distance=[-5.0, -2.0, -2.0, 0.0, 6.0],
     speed=[-3.0, -2.5, -1.0, 0.0, 0.5],
 )
 
 
 def test_not_enough_rows():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         LookupTable()
 
     with pytest.raises(ValueError):
-        LookupTable(key=[0.0, 1.0])
+        LookupTable([0.0, 1.0])
 
 
 def test_not_ascending_key():
     with pytest.raises(ValueError):
-        LookupTable(key=[10.0, 0.0], values=[0.0, 1.0])
+        LookupTable([10.0, 0.0], values=[0.0, 1.0])
 
 
 def test_one_value_table():
     with pytest.raises(ValueError):
-        LookupTable(key=[0.0], value=[0.0])
+        LookupTable([0.0], value=[0.0])
 
 
 def test_duplicate_keys():
     with pytest.raises(ValueError):
-        LookupTable(key=[0.0, 0.0], value=[0.0, 1.0])
+        LookupTable([0.0, 0.0], value=[0.0, 1.0])
 
 
 def test_multiple_row_lengths():
     with pytest.raises(IndexError):
-        LookupTable(key=[0.0, 1.0, 2.0], value=[0.0, 1.0])
+        LookupTable([0.0, 1.0, 2.0], value=[0.0, 1.0])
 
 
 def test_zero_gradient():

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -12,9 +12,6 @@ test_table = LookupTable(
 
 
 def test_not_enough_rows():
-    with pytest.raises(TypeError):
-        LookupTable()
-
     with pytest.raises(ValueError):
         LookupTable([0.0, 1.0])
 

--- a/utilities/lookup.py
+++ b/utilities/lookup.py
@@ -3,34 +3,25 @@ from utilities.functions import clamp
 
 
 class LookupTable:
-    def __init__(self, **kwargs: Sequence[float]) -> None:
-        if len(kwargs.keys()) < 2:
+    def __init__(self, key_row: Sequence[float], **kwargs: Sequence[float]) -> None:
+        # Find length of table based on first row, which should be the key
+        if key_row != sorted(key_row):
+            raise ValueError("LookupTable: Key values must be in ascending order!")
+
+        self.key_values = tuple(key_row)
+        self.table_length = len(key_row)
+
+        if self.table_length < 2:
+            raise ValueError("LookupTable: Should have more than one value!")
+
+        if self.table_length != len(set(key_row)):
+            raise ValueError("LookupTable: Should not have duplicate key value!")
+
+        if len(kwargs.keys()) < 1:
             raise ValueError("LookupTable: Must have more than one row!")
 
-        key_found = False
         self.rows = {}
         for key, val in kwargs.items():
-            # Find length of table based on first row, which should be the key
-            if not key_found:
-                self.key_name = key
-
-                if val != sorted(val):
-                    raise ValueError(
-                        "LookupTable: Key values must be in ascending order!"
-                    )
-
-                self.key_values = tuple(val)
-                self.table_length = len(val)
-
-                if self.table_length < 2:
-                    raise ValueError("LookupTable: Should have more than one value!")
-
-                if self.table_length != len(set(val)):
-                    raise ValueError("LookupTable: Should have duplicate value in key!")
-
-                key_found = True
-                continue
-
             # Convert to tuple so values are immutable
             self.rows[key] = tuple(val)
 


### PR DESCRIPTION
Fixed error typo
Lookup table no longer treats key_row as a keyword argument so no need to name it.
Adjusted tests to accomodate this argument change
