### PR TITLE
Bail tests after 2 failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           pdm install
           pdm run python -m ensurepip
           pdm run python -m pip install coverage pytest-github-actions-annotate-failures
-      - run: pdm run robotpy coverage test -- -v
+      - run: pdm run robotpy coverage test
       - run: pdm run coverage xml
       - uses: codecov/codecov-action@v3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ module = "photonlibpy.*"
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
-addopts = "--strict-markers"
+addopts = "--strict-markers -v --maxfail=2"
 pythonpath = "."
 testpaths = ["tests"]
 xfail_strict = true


### PR DESCRIPTION
[Two is the magic number](https://github.com/thedropbears/pycrescendo/actions/runs/8028095857/job/21932873823?pr=115#step:5:84), and [the magic number is two](https://github.com/thedropbears/pycrescendo/actions/runs/8028413161/job/21933586706?pr=137#step:5:40). [Three is right out](https://github.com/thedropbears/pycrescendo/actions/runs/8028491889/job/21933747724?pr=137#step:5:40).

This sets `--maxfail=2` whenever we run the tests (including in deploy).

This also makes the tests default to verbose mode.