### PR TITLE
test_fuzz: Reduce station parameter when running locally

### DIFF
--- a/tests/fuzz_test.py
+++ b/tests/fuzz_test.py
@@ -81,13 +81,13 @@ def fuzz_xbox_gamepad(gamepad: wpilib.simulation.XboxControllerSim) -> None:
 
 def get_alliance_stations() -> list[str]:
     stations = (1, 2, 3)
-    if "CI" in os.environ:
+    if "CI" in os.environ:  # pragma: no branch
         return [
             f"{alliance}{station}"
             for alliance in ("Blue", "Red")
             for station in stations
         ]
-    else:
+    else:  # pragma: no cover
         return [f"Blue{random.choice(stations)}", f"Red{random.choice(stations)}"]
 
 


### PR DESCRIPTION
This removes 10 test runs during local tests, e.g. pre-deploy tests. On my laptop, this reduces the total test runtime from 41s to 34s.

All the tests will still run in CI.

Supersedes #177.