### PR TITLE
pyfrc_test: Disable test_practice

### DIFF
--- a/tests/pyfrc_test.py
+++ b/tests/pyfrc_test.py
@@ -2,12 +2,10 @@
 from pyfrc.tests import (
     test_disabled,
     test_operator_control,
-    test_practice,
 )
 
 # Make pyflakes happy about our imports.
 __all__ = (
     "test_disabled",
     "test_operator_control",
-    "test_practice",
 )


### PR DESCRIPTION
This takes 14s on my laptop. With this, the tests now take a total of 21s for me.

In practice, our fuzz tests likely hit more code paths than this test which simply has the robot sit in one spot.