### PR TITLE
autonomous: Add get_starting_pose() method

### DIFF
--- a/autonomous/base.py
+++ b/autonomous/base.py
@@ -75,10 +75,8 @@ class AutoBase(AutonomousStateMachine):
 
     def on_enable(self):
         # Setup starting position in the simulator
-        if RobotBase.isSimulation() and self.starting_pose is not None:
-            starting_pose = self.starting_pose
-            if not game.is_red():
-                starting_pose = game.field_flip_pose2d(self.starting_pose)
+        starting_pose = self.get_starting_pose()
+        if RobotBase.isSimulation() and starting_pose is not None:
             self.chassis.set_pose(starting_pose)
         super().on_enable()
 
@@ -90,6 +88,14 @@ class AutoBase(AutonomousStateMachine):
                 last.pose.translation() - self.chassis.get_pose().translation()
             ).norm() < self.SHOOTING_POSITION_TOLERANCE
         return False
+
+    def get_starting_pose(self) -> Pose2d | None:
+        starting_pose = self.starting_pose
+        if starting_pose is None:
+            return None
+        if not game.is_red():
+            starting_pose = game.field_flip_pose2d(starting_pose)
+        return starting_pose
 
     @state(first=True)
     def initialise(self) -> None:


### PR DESCRIPTION
This will be useful for indicating to the drive team whether the robot is in the intended starting position for the selected autonomous mode. That code could look something like this:

```py
def disabledPeriodic(self):
    ...

    selected_auto = self._automodes.chooser.getSelected()
    if isinstance(selected_auto, AutoBase):
        intended_start_pose = selected_auto.get_starting_pose()
        if intended_start_pose is not None: ...
```

(yes, the above snippet depends on magicbot privates. I don't really see any other way to achieve this.)