### PR TITLE
ci: Update to node20 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: pdm-project/setup-pdm@v3
+      - uses: actions/checkout@v4
+      - uses: pdm-project/setup-pdm@v4
         with:
           cache: true
       - name: Install dependencies
@@ -23,21 +25,23 @@ jobs:
           pdm run python -m pip install coverage pytest-github-actions-annotate-failures
       - run: pdm run robotpy coverage test
       - run: pdm run coverage xml
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
+        with:
+          use_oidc: true
 
   mypy:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: pdm-project/setup-pdm@v3
+      - uses: actions/checkout@v4
+      - uses: pdm-project/setup-pdm@v4
         with:
           cache: true
       - name: Install dependencies
         run: |
           pdm install
       - name: mypy
-        uses: liskin/gh-problem-matcher-wrap@v2
+        uses: liskin/gh-problem-matcher-wrap@v3
         with:
           linters: mypy
           run: pdm run mypy --show-column-numbers .


### PR DESCRIPTION
Squash the warnings about node16 actions: https://github.com/thedropbears/pycrescendo/actions/runs/9144326665